### PR TITLE
Allow to use the color blue and the fingerprint icon

### DIFF
--- a/src/opener/parser.ts
+++ b/src/opener/parser.ts
@@ -98,8 +98,8 @@ export function parseOpenerParams(rawHash: string): Container {
     const container: Container = {
         name,
         url,
-        color: color && allowedContainerColors.indexOf(color) ? color : undefined,
-        icon: icon && allowedContainerIcons.indexOf(icon) ? icon : undefined,
+        color: color && allowedContainerColors.indexOf(color) !== -1 ? color : undefined,
+        icon: icon && allowedContainerIcons.indexOf(icon) !== -1 ? icon : undefined,
     };
 
     return container;


### PR DESCRIPTION
Fixes a little bug that does not allow to explicitly set the color blue or the fingerprint icon from the config